### PR TITLE
fix to link with gcc 11

### DIFF
--- a/dediprog.c
+++ b/dediprog.c
@@ -43,7 +43,7 @@
 #define REQTYPE_OTHER_IN (LIBUSB_ENDPOINT_IN | LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_OTHER)	/* 0xC3 */
 #define REQTYPE_EP_OUT (LIBUSB_ENDPOINT_OUT | LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_ENDPOINT)	/* 0x42 */
 #define REQTYPE_EP_IN (LIBUSB_ENDPOINT_IN | LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_ENDPOINT)	/* 0xC2 */
-struct libusb_context *usb_ctx;
+static struct libusb_context *usb_ctx;
 static libusb_device_handle *dediprog_handle;
 static int dediprog_in_endpoint;
 static int dediprog_out_endpoint;

--- a/developerbox_spi.c
+++ b/developerbox_spi.c
@@ -60,7 +60,7 @@ const struct dev_entry devs_developerbox_spi[] = {
 	{0},
 };
 
-struct libusb_context *usb_ctx;
+static struct libusb_context *usb_ctx;
 static libusb_device_handle *cp210x_handle;
 
 static int cp210x_gpio_get(void)


### PR DESCRIPTION
Change-Id: Iec92dd83df67a7ed92ff44203e3a63ea3e62fa72

without this fix with gcc 11 on ubuntu 21.10:
```
/usr/bin/ld: developerbox_spi.o:(.bss+0x0): multiple definition of `usb_ctx'; dediprog.o:(.bss+0x8): first defined here
```